### PR TITLE
#22 채팅 읽지 않은 사람 숫자 + 현재 채팅방 새로운 메시지 유무 확인

### DIFF
--- a/src/main/java/com/example/backend/chat/config/ChannelInterceptorImpl.java
+++ b/src/main/java/com/example/backend/chat/config/ChannelInterceptorImpl.java
@@ -1,0 +1,62 @@
+package com.example.backend.chat.config;
+
+import com.example.backend.chat.service.ChatMessageService;
+import com.example.backend.chat.service.ChatMessageService2;
+import com.example.backend.user.token.AuthToken;
+import com.example.backend.user.token.AuthTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class ChannelInterceptorImpl implements ChannelInterceptor {
+
+    private final AuthTokenProvider tokenProvider;
+    private final ChatMessageService2 chatMessageService2;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+        if (StompCommand.CONNECT == accessor.getCommand()) {
+
+            String tokenStr = accessor.getFirstNativeHeader("Authorization");
+            AuthToken token = tokenProvider.convertAuthToken(tokenStr);
+            token.validate();
+
+        } else if (StompCommand.SUBSCRIBE == accessor.getCommand()) {
+
+            String tokenStr = accessor.getFirstNativeHeader("Authorization");
+            AuthToken token = tokenProvider.convertAuthToken(tokenStr);
+            token.validate();
+            String email = token.getTokenClaims().getSubject();
+
+            String roomId = chatMessageService2.getRoomId(Optional.ofNullable((String) message.getHeaders().get("simpDestination")));
+            String sessionId = (String) message.getHeaders().get("simpSessionId");
+            // 채팅방 입장한 사람 수 ++
+            // 입장한 userId 와 sessionId 맵핑
+            chatMessageService2.plusParticipant(roomId);
+            chatMessageService2.mapSessionAndParticipant(email, roomId, sessionId);
+
+        } else if (StompCommand.DISCONNECT == accessor.getCommand()) {
+
+            // Disconnect 시 sessionId 정보 획득 가능
+            // Subscribe 시 맵핑 해뒀던 userId 로 맵핑을 없애고 해당 방의  roomId 정보 획득
+            // roomId 로 해당 채팅방 입장한 사람 수 --
+            String sessionId = (String) message.getHeaders().get("simpSessionId");
+            String roomId = chatMessageService2.exitParticipant(sessionId);
+            if (roomId != null) {
+                chatMessageService2.minusParticipantCount(roomId);
+            }
+
+        }
+        return message;
+    }
+}

--- a/src/main/java/com/example/backend/chat/config/WebSocketConfig.java
+++ b/src/main/java/com/example/backend/chat/config/WebSocketConfig.java
@@ -2,6 +2,7 @@ package com.example.backend.chat.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -11,6 +12,8 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @EnableWebSocketMessageBroker
 @Configuration
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final ChannelInterceptorImpl channelInterceptor;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -25,6 +28,12 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.addEndpoint("/ws")
                 .setAllowedOriginPatterns("*")
                 .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+
+        registration.interceptors(channelInterceptor);
     }
 
 }

--- a/src/main/java/com/example/backend/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/example/backend/chat/controller/ChatMessageController.java
@@ -43,7 +43,7 @@ public class ChatMessageController {
     ) {
         LoadUser.loginAndNickCheck();
         System.out.println("메세지");
-        Page<ChatMessageResponseDto> responseDtoList = chatMessageService.getSavedMessages(roomId);
+        Page<ChatMessageResponseDto> responseDtoList = chatMessageService.getSavedMessages(roomId, LoadUser.getEmail());
         return ResponseEntity.status(HttpStatus.OK).body(responseDtoList);
     }
 }

--- a/src/main/java/com/example/backend/chat/domain/ChatMessage.java
+++ b/src/main/java/com/example/backend/chat/domain/ChatMessage.java
@@ -30,6 +30,9 @@ public class ChatMessage extends BaseTime {
     @Column
     private String message;
 
+    @Column
+    private Long notRead;
+
     @ManyToOne
     @JoinColumn
     private User user;
@@ -40,6 +43,15 @@ public class ChatMessage extends BaseTime {
         this.sender = user.getUsername();
         this.message = requestDto.getMessage();
         this.user = user;
+    }
+
+    public ChatMessage(ChatMessageRequestDto requestDto, User user, Long notRead) {
+        this.type = requestDto.getType();
+        this.roomId = requestDto.getRoomId();
+        this.sender = user.getUsername();
+        this.message = requestDto.getMessage();
+        this.user = user;
+        this.notRead = notRead;
     }
 
     public ChatMessage(ChatMessageRequestDto requestDto) {

--- a/src/main/java/com/example/backend/chat/domain/Participant.java
+++ b/src/main/java/com/example/backend/chat/domain/Participant.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Getter
 @Entity
@@ -14,6 +15,9 @@ public class Participant {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
+
+    @Column
+    private LocalDateTime exitTime;
 
     @ManyToOne
     @JoinColumn
@@ -26,6 +30,11 @@ public class Participant {
     public Participant(User user, ChatRoom room) {
         this.user = user;
         this.chatRoom = room;
+        this.exitTime = LocalDateTime.now();
+    }
+
+    public void exit() {
+        this.exitTime = LocalDateTime.now();
     }
 
 }

--- a/src/main/java/com/example/backend/chat/dto/response/ChatMessageResponseDto.java
+++ b/src/main/java/com/example/backend/chat/dto/response/ChatMessageResponseDto.java
@@ -22,6 +22,7 @@ public class ChatMessageResponseDto {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createdDate;
     private String profileImageUrl;
+    private Long notRead;
 
     public ChatMessageResponseDto(ChatMessage message) {
         this.type = message.getType();
@@ -36,6 +37,13 @@ public class ChatMessageResponseDto {
         if (message.getUser() != null) {
             this.profileImageUrl = message.getUser().getProfileImageUrl();
         }
+        if (message.getNotRead() != null) {
+            this.notRead = message.getNotRead();
+        }
+    }
+
+    public void read() {
+        notRead--;
     }
 
 }

--- a/src/main/java/com/example/backend/chat/dto/response/ChatRoomResponseDto.java
+++ b/src/main/java/com/example/backend/chat/dto/response/ChatRoomResponseDto.java
@@ -17,6 +17,7 @@ public class ChatRoomResponseDto implements Comparable<ChatRoomResponseDto> {
     private String name;
     private List<ParticipantResponseDto> participantList = new ArrayList<>();
     private LocalDateTime lastMessage;
+    private boolean newMessage;
 
     public ChatRoomResponseDto(ChatRoom room, User user) {
         this.roomId = room.getRoomId();
@@ -29,6 +30,20 @@ public class ChatRoomResponseDto implements Comparable<ChatRoomResponseDto> {
             this.participantList.add(new ParticipantResponseDto(p));
         }
         this.lastMessage = room.getLastMessage();
+    }
+
+    public ChatRoomResponseDto(ChatRoom room, User user, boolean newMessage) {
+        this.roomId = room.getRoomId();
+        this.name = room.getName();
+        for (Participant p : room.getParticipantList()) {
+            // Front 에서 채팅방 사진 설정을 위해 자기 자신의 정보는 Response 에서 제외 요청
+            if (p.getUser() == user) {
+                continue;
+            }
+            this.participantList.add(new ParticipantResponseDto(p));
+        }
+        this.lastMessage = room.getLastMessage();
+        this.newMessage = newMessage;
     }
 
     @Override

--- a/src/main/java/com/example/backend/chat/repository/ParticipantRepository.java
+++ b/src/main/java/com/example/backend/chat/repository/ParticipantRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
     List<Participant> findAllByUser(User user);
+
+    Optional<Participant> findByUserAndChatRoom(User user, ChatRoom room);
 }

--- a/src/main/java/com/example/backend/chat/service/ChatMessageService.java
+++ b/src/main/java/com/example/backend/chat/service/ChatMessageService.java
@@ -7,6 +7,7 @@ import com.example.backend.chat.redis.RedisPub;
 import com.example.backend.chat.redis.RedisRepository;
 import com.example.backend.chat.repository.ChatMessageRepository;
 import com.example.backend.chat.repository.ChatRoomRepository;
+import com.example.backend.chat.repository.ParticipantRepository;
 import com.example.backend.exception.CustomException;
 import com.example.backend.exception.ErrorCode;
 import com.example.backend.notification.domain.Notification;
@@ -39,6 +40,8 @@ public class ChatMessageService {
     private final RedisRepository redisRepository;
     private final RedisPub redisPub;
     private final NotificationRepository notificationRepository;
+    private final ChatMessageService2 chatMessageService2;
+    private final ParticipantRepository participantRepository;
 
     @Transactional
     public void sendChatMessage(ChatMessageRequestDto message, String email) {
@@ -87,11 +90,18 @@ public class ChatMessageService {
     @Transactional
     public void saveChatMessage(ChatMessageRequestDto message) {
 
+        // participant 숫자로 read 숫자 계산
+        Long participantCount = chatMessageService2.getParticipantCount(message.getRoomId());
+        ChatRoom chatRoom = chatRoomRepository.findById(message.getRoomId()).orElseThrow(
+                () -> new CustomException(ErrorCode.ROOM_NOT_FOUND)
+        );
+        Long notRead = chatRoom.getParticipantList().size() - participantCount;
+
         if (!Objects.equals(message.getSender(), "[알림]")) {
             User user = userRepository.findByUsername(message.getSender()).orElseThrow(
                     () -> new CustomException(ErrorCode.USER_NOT_FOUND)
             );
-            chatMessageRepository.save(new ChatMessage(message, user));
+            chatMessageRepository.save(new ChatMessage(message, user, notRead));
         } else {
             chatMessageRepository.save(new ChatMessage(message));
         }
@@ -99,11 +109,26 @@ public class ChatMessageService {
     }
 
     // 페이징으로 받아서 무한 스크롤 가능할듯
-    public Page<ChatMessageResponseDto> getSavedMessages(String roomId) {
+    public Page<ChatMessageResponseDto> getSavedMessages(String roomId, String email) {
 
+        User user = userRepository.findByEmail(email).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId).orElseThrow(
+                () -> new CustomException(ErrorCode.ROOM_NOT_FOUND)
+        );
+        Participant participant = participantRepository.findByUserAndChatRoom(user, chatRoom).orElseThrow(
+                () -> new CustomException(ErrorCode.PARTICIPANT_NOT_FOUND)
+        );
         Pageable pageable = PageRequest.of(0, 100, Sort.by("createdDate").descending());
         Page<ChatMessage> messagePage = chatMessageRepository.findAllByRoomId(pageable, roomId);
-        return messagePage.map(ChatMessageResponseDto::new);
+        Page<ChatMessageResponseDto> responseDtoPage = messagePage.map(ChatMessageResponseDto::new);
+        for (ChatMessageResponseDto c : responseDtoPage) {
+            if (c.getCreatedDate().isAfter(participant.getExitTime())) {
+                c.read();
+            }
+        }
+        return responseDtoPage;
 
     }
 

--- a/src/main/java/com/example/backend/chat/service/ChatMessageService2.java
+++ b/src/main/java/com/example/backend/chat/service/ChatMessageService2.java
@@ -1,0 +1,95 @@
+package com.example.backend.chat.service;
+
+import com.example.backend.chat.domain.ChatRoom;
+import com.example.backend.chat.domain.Participant;
+import com.example.backend.chat.repository.ChatRoomRepository;
+import com.example.backend.chat.repository.ParticipantRepository;
+import com.example.backend.exception.CustomException;
+import com.example.backend.exception.ErrorCode;
+import com.example.backend.msg.MsgEnum;
+import com.example.backend.user.domain.User;
+import com.example.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.Resource;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageService2 {
+
+    @Resource(name = "redisTemplate")
+    private HashOperations<String, String, String> hashOperations;
+
+    @Resource(name = "redisTemplate")
+    private ValueOperations<String, String> valueOperations;
+
+    private final UserRepository userRepository;
+    private final ParticipantRepository participantRepository;
+    private final ChatRoomRepository chatRoomRepository;
+
+    public String getRoomId(Optional<String> simpDestination) {
+        if (simpDestination.isEmpty()) {
+            throw new CustomException(ErrorCode.SUBSCRIBE_ERROR);
+        }
+        int lastIndex = simpDestination.get().lastIndexOf('/');
+        if (lastIndex != -1) {
+            return simpDestination.get().substring(lastIndex + 1);
+        } else {
+            return "";
+        }
+    }
+
+    public Long getParticipantCount(String roomId) {
+        return Long.parseLong(Optional.ofNullable(valueOperations.get(MsgEnum.COUNT_PARTICIPANT.getMsg() + "_" + roomId)).orElse("0"));
+    }
+
+    public Long plusParticipant(String roomId) {
+        return Optional.ofNullable(valueOperations.increment(MsgEnum.COUNT_PARTICIPANT.getMsg() + "_" + roomId)).orElse(0L);
+    }
+
+    public Long minusParticipantCount(String roomId) {
+        return Optional.ofNullable(valueOperations.decrement(MsgEnum.COUNT_PARTICIPANT.getMsg() + "_" + roomId)).orElse(0L);
+    }
+
+    public void mapSessionAndParticipant(String email, String roomId, String sessionId) {
+        Participant participant = this.findParticipant(email, roomId);
+        hashOperations.put(MsgEnum.SESSION_PARTICIPANT_MAPPING.getMsg(), sessionId, participant.getId().toString());
+    }
+
+    @Transactional
+    public Participant findParticipant(String email, String roomId) {
+        User user = userRepository.findByEmail(email).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+        ChatRoom room = chatRoomRepository.findById(roomId).orElseThrow(
+                () -> new CustomException(ErrorCode.ROOM_NOT_FOUND)
+        );
+        return participantRepository.findByUserAndChatRoom(user, room).orElseThrow(
+                () -> new CustomException(ErrorCode.PARTICIPANT_NOT_FOUND)
+        );
+    }
+
+    public String exitParticipant(String sessionId) {
+        String Id = hashOperations.get(MsgEnum.SESSION_PARTICIPANT_MAPPING.getMsg(), sessionId);
+        if (Id != null) {
+            Long participantId = Long.parseLong(Id);
+            return this.changeExitTime(participantId);
+        }
+        return null;
+    }
+
+    @Transactional
+    public String changeExitTime(Long id) {
+        Participant participant = participantRepository.findById(id).orElseThrow(
+                () -> new CustomException(ErrorCode.PARTICIPANT_NOT_FOUND)
+        );
+        participant.exit();
+        return participant.getChatRoom().getRoomId();
+    }
+
+}

--- a/src/main/java/com/example/backend/chat/service/ChatRoomService.java
+++ b/src/main/java/com/example/backend/chat/service/ChatRoomService.java
@@ -83,7 +83,12 @@ public class ChatRoomService {
             ChatRoom room = chatRoomRepository.findById(p.getChatRoom().getRoomId()).orElseThrow(
                     () -> new CustomException(ErrorCode.ROOM_NOT_FOUND)
             );
-            ChatRoomResponseDto responseDto = new ChatRoomResponseDto(room, user);
+            ChatRoomResponseDto responseDto;
+            if (p.getExitTime().isBefore(room.getLastMessage())) {
+                responseDto = new ChatRoomResponseDto(room, user, true);
+            } else {
+                responseDto = new ChatRoomResponseDto(room, user, false);
+            }
             responseDtoList.add(responseDto);
         }
         Collections.sort(responseDtoList);


### PR DESCRIPTION
- 채팅방 Subscribe 시 sessionId 와 userId 맵핑 (RedisTemplate 메서드를 사용해 Redis caching 활용)
- 채팅방 입장한 사람 수 ++

- 채팅방 Disconnect 시 sessionId 와 userId 맵핑 정보를 찾아 채팅방 입장한 사람 수 --
- 채팅방에서 퇴장 시 Participant(참여자) 정보에 채팅방 퇴장 시간 최산화

- ChatMessage 정보에 Long notRead 변수 추가 : 채팅방에서 현재 이 메시지를 읽지 않은 사람의 수
- 채팅 메시지 새로 작성 시 : 채팅 메시지 notRead = 채팅방의 전체 사람 수 - 현재 채팅방에 들어와 있는 사람의 수

- 채팅방 내용 불러오기 시 Participant(참여자) 의 퇴장 시간을 기준으로 각 메시지의 notRead 정보를 최신화

- 채팅방 조회 시 boolean newMessage 변수 추가
- 채팅방을 조회한 유저를 기준으로 참가자 정보를 찾아 exitTime(퇴장 시간) 과 비교하여 새로운 메시지 유무를 알려주는 정보 추가